### PR TITLE
Add info on how to use the Stripe-Account header

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,19 @@ stripe.customers.create({
 });
 ```
 
+To use the `Stripe-Account` header, simply pass an extra options hash:
+
+```js
+// Retrieve the balance for a connected account:
+stripe.balance.retrieve({
+  stripe_account: "acct_foo"
+}).then(function(balance) {
+  // The balance object for the connected account
+}, function(err) {
+  // Error
+});
+```
+
 ### Available resources & methods
 
 *Where you see `params` it is a plain JavaScript object, e.g. `{ email: 'foo@example.com' }`*


### PR DESCRIPTION
The only place I could find this info before was on [this one page](https://stripe.com/docs/connect/payments-fees) of the docs, pointed out to me in IRC. Figured the README was a much better place for it.
